### PR TITLE
Changed the path to the install.sh script to be the location of the library

### DIFF
--- a/tasks/archive/archive_install.yml
+++ b/tasks/archive/archive_install.yml
@@ -28,7 +28,7 @@
 
 - name: gcloud | Archive | Install into Path
   command: >-
-    {{ gcloud_archive_path }}/install.sh --quiet
+    {{ gcloud_library_path }}/install.sh --quiet
     --usage-reporting {{ gcloud_usage_reporting | lower }}
     {% if gcloud_profile_path %}
       --rc-path {{ gcloud_profile_path }}


### PR DESCRIPTION
Previously this was set to the location where the archive was downloaded to which is the parent directory of the install.sh script. This would cause the task that runs the install script to fail as it would not find the script successfully.